### PR TITLE
Merge with feature.xml and postpone resolution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
 kotlinDslPluginOptions {
   experimentalWarning.set(false)
 }
+
 gradlePlugin {
   plugins {
     create("coronium-bundle") {
@@ -41,6 +42,14 @@ gradlePlugin {
       implementationClass = "mb.coronium.plugin.EmbeddingPlugin"
     }
   }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+        }
+    }
 }
 
 tasks.withType<Test> {

--- a/src/main/kotlin/mb/coronium/mavenize/StatelessConversions.kt
+++ b/src/main/kotlin/mb/coronium/mavenize/StatelessConversions.kt
@@ -91,6 +91,9 @@ fun Feature.Dependency.Coordinates.toMaven(
   classifier: String? = null,
   extension: String? = null
 ): DependencyCoordinates {
+  if (version == null) {
+    throw IllegalStateException("Cannot convert coordinates without version to Maven")
+  }
   val version = this.version.toMaven()
   return DependencyCoordinates(groupId, id, version, classifier, extension)
 }

--- a/src/main/kotlin/mb/coronium/plugin/FeaturePlugin.kt
+++ b/src/main/kotlin/mb/coronium/plugin/FeaturePlugin.kt
@@ -1,10 +1,8 @@
 package mb.coronium.plugin
 
-import mb.coronium.mavenize.toEclipse
 import mb.coronium.mavenize.toMaven
 import mb.coronium.model.eclipse.BuildProperties
 import mb.coronium.model.eclipse.Feature
-import mb.coronium.model.maven.MavenVersion
 import mb.coronium.plugin.internal.*
 import mb.coronium.task.EclipseRun
 import mb.coronium.task.PrepareEclipseRunConfig
@@ -61,9 +59,6 @@ class FeaturePlugin : Plugin<Project> {
     project.pluginManager.apply(MavenizePlugin::class)
     val mavenized = project.mavenizedEclipseInstallation()
 
-    // Make sure the configuration is resolved
-    bundleConfig.resolvedConfiguration
-
     // Build feature model from feature.xml and Gradle project.
     val feature = run {
       val builder = Feature.Builder()
@@ -86,15 +81,6 @@ class FeaturePlugin : Plugin<Project> {
           error("Cannot configure Eclipse feature project; no project version was set, nor has a version been set in $featureXmlFile")
         }
         builder.version = project.eclipseVersion
-      }
-      // Add dependencies from Gradle project.
-      for(dependency in bundleConfig.dependencies) {
-        log.info("Dependency = $dependency with version = ${dependency.version}")
-        if(dependency.version == null) {
-          error("Cannot convert dependency $dependency to a feature dependency, as it it has no version")
-        }
-        val version = MavenVersion.parse(dependency.version!!).toEclipse()
-        builder.addOrMerge(dependency.name, version)
       }
       builder.build()
     }
@@ -140,13 +126,13 @@ class FeaturePlugin : Plugin<Project> {
     val featureXmlDir = project.buildDir.resolve("featureXml")
     val featureXmlTask = project.tasks.create("featureXmlTask") {
       // Depend on (files from) bundle configuration because dependencies in this configuration affect the feature model.
-      dependsOn(bundleConfig)
       inputs.files(bundleConfig)
       val featureXmlFile = featureXmlDir.resolve("feature.xml").toPath()
       outputs.file(featureXmlFile)
       doLast {
+        val mergedFeature = feature.mergeWith(bundleConfig)
         Files.newOutputStream(featureXmlFile).buffered().use { outputStream ->
-          feature.writeToFeatureXml(outputStream)
+          mergedFeature.writeToFeatureXml(outputStream)
           outputStream.flush()
         }
       }

--- a/src/main/kotlin/mb/coronium/plugin/FeaturePlugin.kt
+++ b/src/main/kotlin/mb/coronium/plugin/FeaturePlugin.kt
@@ -94,7 +94,7 @@ class FeaturePlugin : Plugin<Project> {
           error("Cannot convert dependency $dependency to a feature dependency, as it it has no version")
         }
         val version = MavenVersion.parse(dependency.version!!).toEclipse()
-        builder.dependencies.add(Feature.Dependency(Feature.Dependency.Coordinates(dependency.name, version), true))
+        builder.addOrMerge(dependency.name, version)
       }
       builder.build()
     }

--- a/src/main/kotlin/mb/coronium/plugin/FeaturePlugin.kt
+++ b/src/main/kotlin/mb/coronium/plugin/FeaturePlugin.kt
@@ -61,6 +61,9 @@ class FeaturePlugin : Plugin<Project> {
     project.pluginManager.apply(MavenizePlugin::class)
     val mavenized = project.mavenizedEclipseInstallation()
 
+    // Make sure the configuration is resolved
+    bundleConfig.resolvedConfiguration
+
     // Build feature model from feature.xml and Gradle project.
     val feature = run {
       val builder = Feature.Builder()
@@ -86,11 +89,12 @@ class FeaturePlugin : Plugin<Project> {
       }
       // Add dependencies from Gradle project.
       for(dependency in bundleConfig.dependencies) {
+        log.info("Dependency = $dependency with version = ${dependency.version}")
         if(dependency.version == null) {
           error("Cannot convert dependency $dependency to a feature dependency, as it it has no version")
         }
         val version = MavenVersion.parse(dependency.version!!).toEclipse()
-        builder.dependencies.add(Feature.Dependency(Feature.Dependency.Coordinates(dependency.name, version), false))
+        builder.dependencies.add(Feature.Dependency(Feature.Dependency.Coordinates(dependency.name, version), true))
       }
       builder.build()
     }


### PR DESCRIPTION
This PR solves two issues:

* In the feature project we specify which plugins to include using `bundlePlugin`. We did not merge these `bundlePlugin`s with existing plugins that may occur in feature.xml and it was not possible to specify `unpack = true`.
* Using `bundlePlugin` adds a dependency to the `bundleConfig` configuration. When the plugin is applied, it would read the version of the dependencies. At this point the configuration may not have been resolved, in which case version may be `unspecified`. However, the version is not used until the `feature.xml` file is created. I've changed the code such that it merges the bundleConfig dependencies with the feature.xml dependencies during the execution phase.