### PR TITLE
Support Gradle 8

### DIFF
--- a/plugin/src/main/kotlin/mb/coronium/plugin/BundlePlugin.kt
+++ b/plugin/src/main/kotlin/mb/coronium/plugin/BundlePlugin.kt
@@ -244,7 +244,7 @@ class BundlePlugin : Plugin<Project> {
                     }
                     if (properties.outputDir != null) {
                         @Suppress("UnstableApiUsage")
-                        outputDir = project.file(properties.outputDir)
+                        destinationDirectory.set(project.file(properties.outputDir))
                     }
                 }
             }

--- a/plugin/src/main/kotlin/mb/coronium/plugin/RepositoryPlugin.kt
+++ b/plugin/src/main/kotlin/mb/coronium/plugin/RepositoryPlugin.kt
@@ -396,9 +396,8 @@ class RepositoryPlugin @Inject constructor(
                 repositoryDir.deleteRecursively()
                 repositoryDir.mkdirs()
                 project.javaexec {
-                    main = "-jar"
+                    classpath = project.files(eclipseLauncherPath)
                     args = mutableListOf(
-                        eclipseLauncherPath,
                         "-application", "org.eclipse.equinox.p2.publisher.FeaturesAndBundlesPublisher",
                         "-metadataRepository", "file:/$repositoryDir",
                         "-artifactRepository", "file:/$repositoryDir",
@@ -409,9 +408,8 @@ class RepositoryPlugin @Inject constructor(
                     )
                 }
                 project.javaexec {
-                    main = "-jar"
+                    classpath = project.files(eclipseLauncherPath)
                     args = mutableListOf(
-                        eclipseLauncherPath,
                         "-application", "org.eclipse.equinox.p2.publisher.CategoryPublisher",
                         "-metadataRepository", "file:/$repositoryDir",
                         "-categoryDefinition", "file:/$repositoryXmlFile",

--- a/plugin/src/main/kotlin/mb/coronium/task/EclipseCreateInstallation.kt
+++ b/plugin/src/main/kotlin/mb/coronium/task/EclipseCreateInstallation.kt
@@ -88,8 +88,6 @@ open class EclipseCreateInstallation : JavaExec() {
 
 
     init {
-        main = "-jar"
-
         baseRepositories.value(
             listOf(
                 "https://artifacts.metaborg.org/content/groups/eclipse-2022-06/"
@@ -129,10 +127,8 @@ open class EclipseCreateInstallation : JavaExec() {
         mavenizedExtension.finalizeOsArch()
         val mavenized = project.lazilyMavenize()
 
-        args(
-            mavenized.equinoxLauncherPath(),
-            "-application", "org.eclipse.equinox.p2.director"
-        )
+        classpath = project.files(mavenized.equinoxLauncherPath())
+        args("-application", "org.eclipse.equinox.p2.director")
         baseRepositories.finalizeValue()
         baseRepositories.get().forEach { args("-repository", it) }
         repositories.finalizeValue()

--- a/plugin/src/main/kotlin/mb/coronium/task/EclipseRun.kt
+++ b/plugin/src/main/kotlin/mb/coronium/task/EclipseRun.kt
@@ -34,7 +34,6 @@ open class EclipseRun : JavaExec() {
         product.convention("org.eclipse.platform.ide")
 
         workingDir = eclipseRunConfigFile.parent.toFile()
-        main = "-Dosgi.configuration.cascaded=true"
     }
 
 
@@ -67,12 +66,14 @@ open class EclipseRun : JavaExec() {
         mavenizedExtension.finalizeOsArch()
         val mavenized = project.lazilyMavenize()
 
+        classpath = project.files(mavenized.equinoxLauncherPath())
+
         args(mavenizedExtension.os.get().eclipseExtraJvmArgs)
         args(
+            "-Dosgi.configuration.cascaded=true",
             "-Dosgi.sharedConfiguration.area=.",
             "-Dosgi.sharedConfiguration.area.readOnly=true",
             "-Dosgi.configuration.area=configuration",
-            "-jar", mavenized.equinoxLauncherPath(),
             "-clean", // Clean the OSGi cache so that rewiring occurs, which is needed when bundles change.
             "-data", "workspace",
             "-consoleLog"


### PR DESCRIPTION
To support Gradle 8, some deprecated (removed) features need to be replaced.

## JavaExec
There are some JavaExec tasks that use `main = "-jar"`, which is no longer supported. Instead, according to [this comment](https://github.com/gradle/gradle/issues/1346#issuecomment-504210972), we should be able to just use the JAR in the classpath and remove the `-jar` argument and it should just work with an executable JAR.
